### PR TITLE
Resolved Issue #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Set the mouse sensitivity. Default value is 0.0025. Valid range from 0.0 (exclus
 
     /goto [NAME]
 
+Set game timer. Replace [time_in_seconds] with the desired duration in seconds for your gameplay session. Once the set time limit is reached, the game window will automatically close.
+
+    /addTime [time_in_seconds]
+    
 Teleport to another user.
 If NAME is unspecified, a random user is chosen.
 

--- a/src/main.c
+++ b/src/main.c
@@ -157,6 +157,9 @@ typedef struct {
     Block copy1;
 
     int p_height; /// player height
+    long timeout;
+    bool hasTimeout;  ///timer
+    time_t start;
 } Model;
 
 static Model model;
@@ -2206,6 +2209,12 @@ void parse_command(const char *buffer, int forward) {
     else if (sscanf(buffer, "/cylinder %d", &radius) == 1) {
         cylinder(&g->block0, &g->block1, radius, 0);
     }
+    else if (sscanf(buffer, "/addtime %d", &count) == 1) {
+        g->start = time(NULL);
+        g->hasTimeout = true; ///timer feature
+        g->timeout += count;
+
+    }
     else if (forward) {
         client_talk(buffer);
     }
@@ -2684,6 +2693,7 @@ void reset_model() {
     glfwSetTime(g->day_length / 3.0);
     g->time_changed = 1;
      g->p_height = 2;
+    g->timeout = 0;
 }
 
 int main(int argc, char **argv) {
@@ -2954,6 +2964,13 @@ int main(int argc, char **argv) {
             if (SHOW_ITEM) {
                 render_item(&block_attrib);
             }
+            
+
+            /// Timer
+            time_t _now = time(NULL);
+            time_t elapsed = _now - g->start;
+            if (!g->hasTimeout)
+                elapsed = g->timeout;
 
             /// RENDER TEXT ///
             char text_buffer[1024];
@@ -2965,6 +2982,19 @@ int main(int argc, char **argv) {
                 char am_pm = hour < 12 ? 'a' : 'p';
                 hour = hour % 12;
                 hour = hour ? hour : 12;
+
+				///timer text
+                if (g->hasTimeout)
+                {
+                    snprintf(
+                        text_buffer, 1024,
+                        "(%d, %d) (%.2f, %.2f, %.2f) [%d, %d, %d] %d%cm %dfps Timeout %ld",
+                        chunked(s->x), chunked(s->z), s->x, s->y, s->z,
+                        g->player_count, g->chunk_count,
+                        face_count * 2, hour, am_pm, fps.fps, g->timeout - elapsed);
+                }
+                else
+                {
                 snprintf(
                     text_buffer, 1024,
                     "(%d, %d) (%.2f, %.2f, %.2f) [%d, %d, %d] %d%cm %dfps",
@@ -3040,7 +3070,7 @@ int main(int argc, char **argv) {
             /// SWAP AND POLL ///
             glfwSwapBuffers(g->window);
             glfwPollEvents();
-            if (glfwWindowShouldClose(g->window)) {
+                 if (glfwWindowShouldClose(g->window) || elapsed > g->timeout) { //closes window when time runs out
                 running = 0;
                 break;
             }


### PR DESCRIPTION
This pull request introduces a new feature that allows gamers to set a time limit for how long they can play the game. The feature includes the use of the /addTime command, which enables users to specify the number of seconds to add to their time limit. Once the set time limit is reached, the game window will automatically close. This implementation ensures gamers can manage their time effectively and avoid excessive gaming sessions.